### PR TITLE
Display last event sessions on home screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.github.leonardoxh.f1"
         minSdkVersion(21)
         targetSdkVersion(30)
-        versionCode = 23
-        versionName = "2.1.1"
+        versionCode = 24
+        versionName = "2.2.0"
 
         buildConfigField("String", "DEFAULT_USER_AGENT", "\"RaceControl f1viewer\"")
     }

--- a/app/src/main/java/fr/groggy/racecontrol/tv/core/season/SeasonService.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/core/season/SeasonService.kt
@@ -1,10 +1,18 @@
 package fr.groggy.racecontrol.tv.core.season
 
+import android.net.Uri
 import android.util.Log
+import fr.groggy.racecontrol.tv.core.event.EventRepository
+import fr.groggy.racecontrol.tv.core.session.SessionRepository
 import fr.groggy.racecontrol.tv.core.session.SessionService
-import fr.groggy.racecontrol.tv.f1tv.Archive
-import fr.groggy.racecontrol.tv.f1tv.F1TvClient
+import fr.groggy.racecontrol.tv.f1tv.*
+import fr.groggy.racecontrol.tv.ui.season.browse.Event
+import fr.groggy.racecontrol.tv.ui.season.browse.Image
+import fr.groggy.racecontrol.tv.ui.season.browse.Season
+import fr.groggy.racecontrol.tv.ui.season.browse.Session
+import fr.groggy.racecontrol.tv.utils.coroutines.traverse
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
 import org.threeten.bp.Year
 import javax.inject.Inject
@@ -14,7 +22,9 @@ import javax.inject.Singleton
 class SeasonService @Inject constructor(
     private val seasonRepository: SeasonRepository,
     private val f1Tv: F1TvClient,
-    private val sessionService: SessionService
+    private val sessionService: SessionService,
+    private val eventRepository: EventRepository,
+    private val sessionRepository: SessionRepository
 ) {
     companion object {
         private val TAG = SeasonService::class.simpleName
@@ -36,5 +46,60 @@ class SeasonService @Inject constructor(
         val season = f1Tv.getSeason(archive)
         seasonRepository.save(season)
         sessionService.loadSessionsWithImages(season)
+    }
+
+    suspend fun season(archive: Archive): Flow<Season> =
+        seasonRepository.observe(archive)
+            .onEach { Log.d(TAG, "Season changed") }
+            .filterNotNull()
+            .flatMapLatest { season -> events(season.events)
+                .map { events -> Season(
+                    name = season.title,
+                    events = events
+                ) }
+            }
+            .distinctUntilChanged()
+            .onEach { Log.d(TAG, "VM season changed") }
+
+    private fun events(ids: List<F1TvSeasonEvent>): Flow<List<Event>> =
+        eventRepository.observe(ids)
+            .onEach { Log.d(TAG, "Events changed") }
+            .flatMapLatest { events -> events
+                .sortedByDescending { it.period.start }
+                .traverse { event -> sessions(listOf(event.id))
+                    .map { sessions -> Event(
+                        id = event.id,
+                        name = event.name,
+                        sessions = sessions
+                    ) }
+                }
+            }
+            .distinctUntilChanged()
+            .onEach { Log.d(TAG, "VM events changed") }
+
+    private fun sessions(ids: List<F1TvEventId>): Flow<List<Session>> =
+        sessionRepository.observe(ids)
+            .onEach { Log.d(TAG, "Sessions changed") }
+            .flatMapLatest { sessions -> sessions
+                .filter { it.available && it.channels.isNotEmpty() }
+                .sortedByDescending { it.period.start }
+                .traverse { session -> thumbnail(session)
+                    .map { thumbnail -> Session(
+                        id = session.id,
+                        contentId = session.contentId,
+                        name = session.name,
+                        contentSubtype = session.contentSubtype,
+                        thumbnail = thumbnail,
+                        channels = session.channels
+                    ) }
+                }
+            }
+            .distinctUntilChanged()
+            .onEach { Log.d(TAG, "VM sessions changed") }
+
+    private fun thumbnail(session: F1TvSession): Flow<Image> {
+        return flowOf(
+            Image(Uri.parse(session.pictureUrl))
+        )
     }
 }

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/common/CustomListRowPresenter.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/common/CustomListRowPresenter.kt
@@ -1,0 +1,11 @@
+package fr.groggy.racecontrol.tv.ui.common
+
+import androidx.leanback.widget.FocusHighlight
+import androidx.leanback.widget.ListRowPresenter
+
+class CustomListRowPresenter : ListRowPresenter(FocusHighlight.ZOOM_FACTOR_NONE) {
+    init {
+        shadowEnabled = false
+        selectEffectEnabled = false
+    }
+}

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeActivity.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeActivity.kt
@@ -23,7 +23,7 @@ class HomeActivity : FragmentActivity(R.layout.activity_home) {
     }
 
     @Inject
-    lateinit var seasonService: SeasonService
+    internal lateinit var seasonService: SeasonService
 
     override fun onStart() {
         Log.d(TAG, "onStart")

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeActivity.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeActivity.kt
@@ -2,13 +2,38 @@ package fr.groggy.racecontrol.tv.ui.home
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import fr.groggy.racecontrol.tv.R
+import fr.groggy.racecontrol.tv.core.season.SeasonService
+import fr.groggy.racecontrol.tv.f1tv.Archive
+import fr.groggy.racecontrol.tv.utils.coroutines.schedule
+import org.threeten.bp.Duration
+import org.threeten.bp.Year
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class HomeActivity : FragmentActivity(R.layout.activity_home) {
     companion object {
+        private val TAG = HomeActivity::class.simpleName
+
         fun intent(context: Context) = Intent(context, HomeActivity::class.java)
+    }
+
+    @Inject
+    lateinit var seasonService: SeasonService
+
+    override fun onStart() {
+        Log.d(TAG, "onStart")
+        super.onStart()
+        lifecycleScope.launchWhenStarted {
+            schedule(Duration.ofMinutes(1)) {
+                Log.d("Fetching new data", "Lifecycle state is ${lifecycle.currentState}")
+                val currentYear = Year.now().value
+                seasonService.loadSeason(Archive(currentYear))
+            }
+        }
     }
 }

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
@@ -27,6 +27,7 @@ class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
         selectEffectEnabled = false
     }
     private val archivesAdapter = ArrayObjectAdapter(listRowPresenter)
+    private var imageView: ImageView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,6 +50,8 @@ class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
             rightMargin = horizontalMargin
         }
 
+        imageView = requireActivity().findViewById(R.id.teaserImage)
+
         return view
     }
 
@@ -57,8 +60,8 @@ class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
 
         val currentYear = Year.now().value
 
-        val imageView = requireActivity().findViewById<ImageView>(R.id.teaserImage)
-        imageView.setOnClickListener {
+        imageView?.requestFocus()
+        imageView?.setOnClickListener {
             val activity = SeasonBrowseActivity.intent(requireContext(), Archive(currentYear))
             startActivity(activity)
         }

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
@@ -92,7 +92,17 @@ class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
         listRowAdapter.setItems(event.sessions, Session.diffCallback)
 
         if (archivesAdapter.size() == 0) {
-            archivesAdapter.add(ListRow(HeaderItem(event.name + " " + currentYear), listRowAdapter))
+            archivesAdapter.add(
+                ListRow(
+                    HeaderItem(
+                        getString(
+                            R.string.season_last_event,
+                            event.name,
+                            currentYear.toString()
+                        )
+                    ), listRowAdapter
+                )
+            )
             archivesAdapter.add(getArchiveRow(viewModel))
         } else {
             val listRow: ListRow = archivesAdapter.get(0) as ListRow

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
@@ -29,8 +29,7 @@ import org.threeten.bp.Year
 @AndroidEntryPoint
 class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
 
-    private val listRowPresenter = CustomListRowPresenter()
-    private val homeEntriesAdapter = ArrayObjectAdapter(listRowPresenter)
+    private val homeEntriesAdapter = ArrayObjectAdapter(CustomListRowPresenter())
     private var imageView: ImageView? = null
     private val currentYear = Year.now().value
     private var archivesRow: ListRow? = null
@@ -73,6 +72,7 @@ class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
 
         val teaserImageText = requireActivity().findViewById<TextView>(R.id.teaserImageText)
         teaserImageText.text = resources.getString(R.string.teaser_image_text, currentYear)
+        homeEntriesAdapter.clear()
     }
 
     private fun buildRowsAdapter() {
@@ -89,7 +89,7 @@ class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
     private fun onUpdatedSeason(season: Season) {
         val events = season.events.filter { it.sessions.isNotEmpty() }
         if (events.isNotEmpty()) {
-            val event = events[0]
+            val event = events.first()
             val existingListRows = homeEntriesAdapter.unmodifiableList<ListRow>()
             val headerName =
                 getString(R.string.season_last_event, event.name, currentYear.toString())

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeFragment.kt
@@ -1,7 +1,6 @@
 package fr.groggy.racecontrol.tv.ui.home
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -17,6 +16,7 @@ import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import fr.groggy.racecontrol.tv.R
 import fr.groggy.racecontrol.tv.f1tv.Archive
+import fr.groggy.racecontrol.tv.ui.common.CustomListRowPresenter
 import fr.groggy.racecontrol.tv.ui.season.archive.SeasonArchiveActivity
 import fr.groggy.racecontrol.tv.ui.season.browse.Season
 import fr.groggy.racecontrol.tv.ui.season.browse.SeasonBrowseActivity
@@ -28,10 +28,7 @@ import org.threeten.bp.Year
 @AndroidEntryPoint
 class HomeFragment : RowsSupportFragment(), OnItemViewClickedListener {
 
-    private val listRowPresenter = ListRowPresenter(FocusHighlight.ZOOM_FACTOR_NONE).apply {
-        shadowEnabled = false
-        selectEffectEnabled = false
-    }
+    private val listRowPresenter = CustomListRowPresenter()
     private val archivesAdapter = ArrayObjectAdapter(listRowPresenter)
     private var imageView: ImageView? = null
     private val currentYear = Year.now().value

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeViewModel.kt
@@ -4,13 +4,20 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.groggy.racecontrol.tv.core.season.SeasonService
 import fr.groggy.racecontrol.tv.f1tv.Archive
+import fr.groggy.racecontrol.tv.ui.season.browse.Season
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val seasonService: SeasonService
-): ViewModel() {
+) : ViewModel() {
+
     fun listArchive(): List<Archive> {
         return seasonService.listArchive()
+    }
+
+    suspend fun getCurrentSeason(archive: Archive): Flow<Season> {
+        return seasonService.season(archive)
     }
 }

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/home/HomeViewModel.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val seasonService: SeasonService
-) : ViewModel() {
+): ViewModel() {
 
     fun listArchive(): List<Archive> {
         return seasonService.listArchive()

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/archive/SeasonArchiveFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/archive/SeasonArchiveFragment.kt
@@ -9,13 +9,15 @@ import androidx.leanback.widget.*
 import dagger.hilt.android.AndroidEntryPoint
 import fr.groggy.racecontrol.tv.R
 import fr.groggy.racecontrol.tv.f1tv.Archive
+import fr.groggy.racecontrol.tv.ui.common.CustomListRowPresenter
 import fr.groggy.racecontrol.tv.ui.season.browse.SeasonBrowseActivity
 
 @Keep
 @AndroidEntryPoint
 class SeasonArchiveFragment : BrowseSupportFragment(), OnItemViewClickedListener {
 
-    private val archivesAdapter = ArrayObjectAdapter(ListRowPresenter())
+    private val listRowPresenter = CustomListRowPresenter()
+    private val archivesAdapter = ArrayObjectAdapter(listRowPresenter)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/archive/SeasonArchiveFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/archive/SeasonArchiveFragment.kt
@@ -16,8 +16,7 @@ import fr.groggy.racecontrol.tv.ui.season.browse.SeasonBrowseActivity
 @AndroidEntryPoint
 class SeasonArchiveFragment : BrowseSupportFragment(), OnItemViewClickedListener {
 
-    private val listRowPresenter = CustomListRowPresenter()
-    private val archivesAdapter = ArrayObjectAdapter(listRowPresenter)
+    private val archivesAdapter = ArrayObjectAdapter(CustomListRowPresenter())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/browse/SeasonBrowseFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/browse/SeasonBrowseFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import fr.groggy.racecontrol.tv.R
 import fr.groggy.racecontrol.tv.f1tv.Archive
+import fr.groggy.racecontrol.tv.ui.common.CustomListRowPresenter
 import fr.groggy.racecontrol.tv.ui.event.EventListRowDiffCallback
 import fr.groggy.racecontrol.tv.ui.session.SessionCardPresenter
 import fr.groggy.racecontrol.tv.ui.session.browse.SessionBrowseActivity
@@ -43,7 +44,8 @@ class SeasonBrowseFragment : BrowseSupportFragment(), OnItemViewClickedListener 
     private val eventListRowDiffCallback = EventListRowDiffCallback()
     private val sessionCardPresenter = SessionCardPresenter()
 
-    private val eventsAdapter = ArrayObjectAdapter(ListRowPresenter())
+    private val listRowPresenter = CustomListRowPresenter()
+    private val eventsAdapter = ArrayObjectAdapter(listRowPresenter)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate")
@@ -92,9 +94,15 @@ class SeasonBrowseFragment : BrowseSupportFragment(), OnItemViewClickedListener 
         return listRow
     }
 
-    override fun onItemClicked(itemViewHolder: Presenter.ViewHolder, item: Any, rowViewHolder: RowPresenter.ViewHolder, row: Row) {
+    override fun onItemClicked(
+        itemViewHolder: Presenter.ViewHolder,
+        item: Any,
+        rowViewHolder: RowPresenter.ViewHolder,
+        row: Row
+    ) {
         val session = item as Session
-        val intent = SessionBrowseActivity.intent(requireActivity(), session.id.value, session.contentId)
+        val intent =
+            SessionBrowseActivity.intent(requireActivity(), session.id.value, session.contentId)
         startActivity(intent)
     }
 

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/browse/SeasonBrowseFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/browse/SeasonBrowseFragment.kt
@@ -54,7 +54,7 @@ class SeasonBrowseFragment : BrowseSupportFragment(), OnItemViewClickedListener 
         val viewModel: SeasonBrowseViewModel by viewModels({ requireActivity() })
         val archive = findArchive(requireActivity())
         lifecycleScope.launchWhenStarted {
-            viewModel.season(archive).asLiveData().observe(viewLifecycleOwner, ::onUpdatedSeason)
+            viewModel.getSeason(archive).asLiveData().observe(viewLifecycleOwner, ::onUpdatedSeason)
         }
     }
 

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/browse/SeasonBrowseFragment.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/browse/SeasonBrowseFragment.kt
@@ -44,8 +44,7 @@ class SeasonBrowseFragment : BrowseSupportFragment(), OnItemViewClickedListener 
     private val eventListRowDiffCallback = EventListRowDiffCallback()
     private val sessionCardPresenter = SessionCardPresenter()
 
-    private val listRowPresenter = CustomListRowPresenter()
-    private val eventsAdapter = ArrayObjectAdapter(listRowPresenter)
+    private val eventsAdapter = ArrayObjectAdapter(CustomListRowPresenter())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate")

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/browse/SeasonBrowseViewModel.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/season/browse/SeasonBrowseViewModel.kt
@@ -1,93 +1,37 @@
 package fr.groggy.racecontrol.tv.ui.season.browse
 
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import fr.groggy.racecontrol.tv.core.event.EventRepository
-import fr.groggy.racecontrol.tv.core.season.SeasonRepository
-import fr.groggy.racecontrol.tv.core.session.SessionRepository
-import fr.groggy.racecontrol.tv.f1tv.*
+import fr.groggy.racecontrol.tv.core.season.SeasonService
+import fr.groggy.racecontrol.tv.f1tv.Archive
+import fr.groggy.racecontrol.tv.f1tv.F1TvChannelId
+import fr.groggy.racecontrol.tv.f1tv.F1TvEventId
+import fr.groggy.racecontrol.tv.f1tv.F1TvSessionId
 import fr.groggy.racecontrol.tv.ui.DataClassByIdDiffCallback
 import fr.groggy.racecontrol.tv.ui.session.SessionCard
-import fr.groggy.racecontrol.tv.utils.coroutines.traverse
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import org.threeten.bp.Year
 import javax.inject.Inject
 
 @HiltViewModel
 class SeasonBrowseViewModel @Inject constructor(
-    private val eventRepository: EventRepository,
-    private val seasonRepository: SeasonRepository,
-    private val sessionRepository: SessionRepository
+    private val seasonService: SeasonService
 ) : ViewModel() {
 
-    companion object {
-        private val TAG = SeasonBrowseViewModel::class.simpleName
+    suspend fun archiveLoaded(archive: Archive): Season {
+        return loaded(seasonService.season(archive))
     }
 
-    suspend fun archiveLoaded(archive: Archive): Season {
-        return loaded(season(archive))
+    suspend fun getSeason(archive: Archive): Flow<Season> {
+        return seasonService.season(archive)
     }
 
     private suspend fun loaded(season: Flow<Season>): Season {
         return season.filter { it.events.isNotEmpty() }.first()
     }
-
-    suspend fun season(archive: Archive): Flow<Season> =
-        seasonRepository.observe(archive)
-            .onEach { Log.d(TAG, "Season changed") }
-            .filterNotNull()
-            .flatMapLatest { season -> events(season.events)
-                .map { events -> Season(
-                    name = season.title,
-                    events = events
-                ) }
-            }
-            .distinctUntilChanged()
-            .onEach { Log.d(TAG, "VM season changed") }
-
-    private fun events(ids: List<F1TvSeasonEvent>): Flow<List<Event>> =
-        eventRepository.observe(ids)
-            .onEach { Log.d(TAG, "Events changed") }
-            .flatMapLatest { events -> events
-                .sortedByDescending { it.period.start }
-                .traverse { event -> sessions(listOf(event.id))
-                    .map { sessions -> Event(
-                        id = event.id,
-                        name = event.name,
-                        sessions = sessions
-                    ) }
-                }
-            }
-            .distinctUntilChanged()
-            .onEach { Log.d(TAG, "VM events changed") }
-
-    private fun sessions(ids: List<F1TvEventId>): Flow<List<Session>> =
-        sessionRepository.observe(ids)
-            .onEach { Log.d(TAG, "Sessions changed") }
-            .flatMapLatest { sessions -> sessions
-                .filter { it.available && it.channels.isNotEmpty() }
-                .sortedByDescending { it.period.start }
-                .traverse { session -> thumbnail(session)
-                    .map { thumbnail -> Session(
-                        id = session.id,
-                        contentId = session.contentId,
-                        name = session.name,
-                        contentSubtype = session.contentSubtype,
-                        thumbnail = thumbnail,
-                        channels = session.channels
-                    ) }
-                }
-            }
-            .distinctUntilChanged()
-            .onEach { Log.d(TAG, "VM sessions changed") }
-
-    private fun thumbnail(session: F1TvSession): Flow<Image> {
-        return flowOf(
-            Image(Uri.parse(session.pictureUrl))
-        )
-    }
-
 }
 
 data class Season(

--- a/app/src/main/java/fr/groggy/racecontrol/tv/ui/session/SessionCardPresenter.kt
+++ b/app/src/main/java/fr/groggy/racecontrol/tv/ui/session/SessionCardPresenter.kt
@@ -1,6 +1,7 @@
 package fr.groggy.racecontrol.tv.ui.session
 
 import android.net.Uri
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.leanback.widget.ImageCardView
@@ -10,7 +11,7 @@ import androidx.leanback.widget.Presenter
 import com.bumptech.glide.Glide
 import fr.groggy.racecontrol.tv.R
 
-class SessionCardPresenter: Presenter() {
+class SessionCardPresenter : Presenter() {
 
     companion object {
         private const val WIDTH = 313
@@ -18,34 +19,37 @@ class SessionCardPresenter: Presenter() {
     }
 
     override fun onCreateViewHolder(parent: ViewGroup): ViewHolder {
-        val view = ImageCardView(parent.context)
-        view.setMainImageDimensions(
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.session_card, parent, false)
+
+        val imageCardView = view.findViewById<ImageCardView>(R.id.image_card_view)
+        imageCardView.setMainImageDimensions(
             WIDTH,
             HEIGHT
         )
-        view.cardType = CARD_TYPE_FLAG_TITLE or CARD_TYPE_FLAG_CONTENT
+        imageCardView.cardType = CARD_TYPE_FLAG_TITLE or CARD_TYPE_FLAG_CONTENT
 
-        view.findViewById<TextView>(R.id.title_text)?.setLines(2)
+        imageCardView.findViewById<TextView>(R.id.title_text)?.setLines(2)
 
         return ViewHolder(view)
     }
 
     override fun onBindViewHolder(viewHolder: ViewHolder, item: Any) {
-        val view = viewHolder.view as ImageCardView
+        val imageCardView = viewHolder.view.findViewById<ImageCardView>(R.id.image_card_view)
         val session = item as SessionCard
 
-        view.titleText = session.name
-        view.contentText = session.contentSubtype
+        imageCardView.titleText = session.name
+        imageCardView.contentText = session.contentSubtype
 
         Glide.with(viewHolder.view.context)
             .load(session.thumbnail?.url)
-            .into(view.mainImageView)
+            .into(imageCardView.mainImageView)
     }
 
     override fun onUnbindViewHolder(viewHolder: ViewHolder) {
-        val view = viewHolder.view as ImageCardView
-        view.badgeImage = null
-        view.mainImage = null
+        val imageCardView = viewHolder.view.findViewById<ImageCardView>(R.id.image_card_view)
+        imageCardView.badgeImage = null
+        imageCardView.mainImage = null
     }
 
 }

--- a/app/src/main/res/drawable/border_shape.xml
+++ b/app/src/main/res/drawable/border_shape.xml
@@ -1,6 +1,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <stroke android:width="2dp" android:color="#FFFFFF" />
-    <solid android:color="#000000" />
+    <solid android:color="@color/card_background" />
     <corners android:radius="0dp" />
     <padding android:left="2dp" android:top="2dp" android:right="2dp" android:bottom="2dp" />
 </shape>

--- a/app/src/main/res/drawable/item_background.xml
+++ b/app/src/main/res/drawable/item_background.xml
@@ -1,4 +1,4 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_selected="true" android:drawable="@drawable/border_shape"/>
-    <item android:state_selected="false" android:drawable="@android:color/black"/>
+    <item android:state_selected="false" android:drawable="@color/card_background"/>
 </selector>

--- a/app/src/main/res/layout/session_card.xml
+++ b/app/src/main/res/layout/session_card.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/item_background">
+
+    <androidx.leanback.widget.ImageCardView
+        android:id="@+id/image_card_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="0dp"/>
+</RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,3 +1,4 @@
 <resources>
     <color name="fastlane_background">#0096a6</color>
+    <color name="card_background">#37474F</color>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="video_quality" translatable="false">%1$dp%2$d</string>
     <string name="season_archives_title" translatable="false">%s - %s</string>
+    <string name="season_last_event" translatable="false">%s %s</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.0")
+        classpath("com.android.tools.build:gradle:4.2.1")
         classpath(kotlin("gradle-plugin", version = "1.4.32"))
 
         val hiltVersion = "2.35.1"


### PR DESCRIPTION
I've added the last event sessions to the home screen for faster access.

![Screenshot_Home_Last_Event](https://user-images.githubusercontent.com/3748388/118360506-3d168d80-b588-11eb-9eec-4d93a4eb9a5d.png)

Please test it espacially with schedule and update every one minute stuff. And if you have a smart idea on how to populate the rows (HomeFragment:89) in an easier and extensible way you're welcome :D

Let me know what your thoughts are :)